### PR TITLE
Ability to recreate Juster instance outside of SDK

### DIFF
--- a/examples/react-ui-demo/package.json
+++ b/examples/react-ui-demo/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.2",
   "private": true,
   "dependencies": {
-    "@juster-finance/sdk": "^0.0.7",
+    "@juster-finance/sdk": "^0.0.9",
+    "@taquito/taquito": "^13.0.0",
+    "@taquito/beacon-wallet": "^13.0.0",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",

--- a/examples/react-ui-demo/src/App.tsx
+++ b/examples/react-ui-demo/src/App.tsx
@@ -10,13 +10,23 @@ import { EventComponent } from './components/Event';
 import { ProvideLiquidityForm } from './components/ProvideLiquidityForm';
 import { BetForm } from './components/BetForm';
 import { WithdrawButton } from './components/WithdrawButton';
+import { TezosToolkit } from "@taquito/taquito";
+import { BeaconWallet } from '@taquito/beacon-wallet';
+import { NetworkType } from '@airgap/beacon-dapp';
 
-
-const juster = Juster.create("testnet");
+const rpcNode = "https://rpc.tzkt.io/ghostnet/";
+const network = NetworkType["GHOSTNET"];
+const appName = "Juster";
+const tezos = new TezosToolkit(rpcNode);
+const provider = new BeaconWallet({
+  name: appName,
+  preferredNetwork: network
+});
+const juster = Juster.create(tezos, provider, "testnet");
 
 
 function App() {
-  const [eventId, setEventId] = useState<number>(9020);
+  const [eventId, setEventId] = useState<number>(10313);
   const [event, setEvent] = useState<EventType | null>(null);
   const [position, setPosition] = useState<PositionType | null>(null);
   const [pkh, setPkh] = useState<string | null>(null);

--- a/packages/juster-sdk/package.json
+++ b/packages/juster-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juster-finance/sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Utilities used to interact with Juster Protocol contract and backend API",
   "main": "dist/lib/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/juster-sdk/src/juster.ts
+++ b/packages/juster-sdk/src/juster.ts
@@ -40,6 +40,7 @@ export class Juster {
     network: NetworkType,
     contractAddress: string,
     tezos: TezosToolkit,
+    provider: BeaconWallet,
     entrypoints: Record<string, any>,
     appName: string,
     graphqlUri: string,
@@ -49,13 +50,7 @@ export class Juster {
   ) {
     this._network = network;
     this._tezos = tezos;
-
-    // TODO: is it possible to get wallet provider using tezos instance?
-    // I did not find it, so I am saving this provider to call requestPermissions
-    this._provider = new BeaconWallet({
-      name: appName,
-      preferredNetwork: network
-    });
+    this._provider = provider;
 
     this._tezos.setWalletProvider(this._provider);
     this._contractAddress = contractAddress;
@@ -79,6 +74,8 @@ export class Juster {
   };
 
   static create(
+    tezos: TezosToolkit,
+    provider: BeaconWallet,
     network: Network,
   ) {
     const networkSettings = config.networks[network];
@@ -98,11 +95,11 @@ export class Juster {
       ratioPrecision
     } = config;
 
-    const tezos = new TezosToolkit(rpcNode);
     return new Juster(
       (<any>NetworkType)[networkName],
       contractAddress,
       tezos,
+      provider,
       entrypoints,
       appName,
       graphqlUri,


### PR DESCRIPTION
- `create` now requires `TezosToolkit` and `BeaconWallet` instances, see `examples/react-ui-demo` for example
- this changes required to change network without creating new instances of `TezosToolkit` and `BeaconWallet`
- this changes allow to reuse `TezosToolkit` and `BeaconWallet` in Pool instance